### PR TITLE
[API]: Retrieve the subjects, artists, image types lists through the API

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -1,11 +1,23 @@
 from fastapi import FastAPI, Body
 import gradio as gr
 from build_dynamic_prompt import *
+from scripts.onebuttonprompt import subjects, artists, imagetypes
 
 def one_button_prompt_api(_: gr.Blocks, app: FastAPI):
     @app.get("/one_button_prompt/version")
     async def version():
         return {"version": 1.0}
+
+    @app.get("/one_button_prompt/config")
+    async def get_config():
+
+        config ={
+             "subjects": subjects,
+             "artists": artists,
+             "imagetypes": imagetypes,
+
+        }
+        return config 
 
     @app.post("/one_button_prompt/prompt/random")
     async def random_prompts(numberofprompts:int = Body(1,title="number of prompts"),


### PR DESCRIPTION
This PR is a follow-up to the previous PR #57. 
It exposes a small subset of the UI configuration to the API. Ideally, we would like to extract all of the UI settings and options used in build_dynamic_prompt function to a dictionary and then expose that through the API. This way, third-party tools will use similar settings to the one used in the main extension.