### PR TITLE
Replace -artist- wildcards when building prompt with onlyartists==True

### DIFF
--- a/build_dynamic_prompt.py
+++ b/build_dynamic_prompt.py
@@ -820,6 +820,9 @@ def build_dynamic_prompt(insanitylevel = 5, forcesubject = "all", artists = "all
 
 
             if(onlyartists == True):
+
+                # replace artist wildcards
+                completeprompt = replacewildcard(completeprompt, insanitylevel, "-artist-", artistlist, False)
                     
                 # clean it up
                 completeprompt = cleanup(completeprompt)

--- a/scripts/onebuttonprompt.py
+++ b/scripts/onebuttonprompt.py
@@ -718,7 +718,6 @@ class Script(scripts.Script):
                 prefixpromptcopy = prefixprompt
                 
                 if(ANDtoggle == "automatic"):
-                    preppedprompt += prefixprompt + ", "
                     if(artist != "none"):
                         preppedprompt += build_dynamic_prompt(insanitylevel,subject,artist, imagetype, True, antistring) 
                     if(subject == "humanoid"):


### PR DESCRIPTION
This should fix #79 

This also removes the added ", " that is currently prepended to the prompt when running in _automatic_ prompt separator mode. Since the prompt only gets cleaned up in `build_dynamic_prompt`, that was left out.