### PR TITLE
fix: invalid import/regex 

### DIFF
--- a/OneButtonPromptNodes.py
+++ b/OneButtonPromptNodes.py
@@ -10,10 +10,10 @@ onebuttonprompt_path = os.path.join(custom_nodes_path, "OneButtonPrompt")
 
 sys.path.append(onebuttonprompt_path)
 
-from build_dynamic_prompt import *
-from csv_reader import *
+from .build_dynamic_prompt import *
+from .csv_reader import *
 
-from one_button_presets import OneButtonPresets
+from .one_button_presets import OneButtonPresets
 OBPresets = OneButtonPresets()
 allpresets = [OBPresets.RANDOM_PRESET_OBP] + list(OBPresets.opb_presets.keys())
 

--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,6 @@ custom_nodes_path = os.path.join(folder_paths.base_path, "custom_nodes")
 onebuttonprompt_path = os.path.join(custom_nodes_path, "OneButtonPrompt")
 sys.path.append(onebuttonprompt_path)
 
-from OneButtonPromptNodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+from .OneButtonPromptNodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
 __all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']

--- a/build_dynamic_prompt.py
+++ b/build_dynamic_prompt.py
@@ -1,9 +1,21 @@
 import random
 import re
-from .csv_reader import *
-from .random_functions import *
-from .one_button_presets import OneButtonPresets
-from .superprompter.superprompter import *
+
+if __package__ is None or __package__ == '':
+    # A1111 style (standalone script or direct module execution)
+    # Use absolute imports for compatibility with A1111 WebUI environment
+    from csv_reader import *
+    from random_functions import *
+    from one_button_presets import OneButtonPresets
+    from superprompter.superprompter import *
+else:
+    # ComfyUI style (imported as a package)
+    # Use relative imports for proper integration with ComfyUI
+    from .csv_reader import *
+    from .random_functions import *
+    from .one_button_presets import OneButtonPresets
+    from .superprompter.superprompter import *
+
 OBPresets = OneButtonPresets()
 
 

--- a/build_dynamic_prompt.py
+++ b/build_dynamic_prompt.py
@@ -1,9 +1,9 @@
 import random
 import re
-from csv_reader import *
-from random_functions import *
-from one_button_presets import OneButtonPresets
-from superprompter.superprompter import *
+from .csv_reader import *
+from .random_functions import *
+from .one_button_presets import OneButtonPresets
+from .superprompter.superprompter import *
 OBPresets = OneButtonPresets()
 
 
@@ -4947,7 +4947,7 @@ def cleanup(completeprompt, advancedprompting, insanitylevel = 5):
         completeprompt = completeprompt.replace("|", " ")
 
     # sometimes if there are not enough artist, we get left we things formed as (:1.2)
-    completeprompt = re.sub('\(\:\d+\.\d+\)', '', completeprompt) 
+    completeprompt = re.sub(r'\(\:\d+\.\d+\)', '', completeprompt)
 
     # lets also remove some wierd stuff on lower insanitylevels
     if(insanitylevel < 7):
@@ -4955,16 +4955,16 @@ def cleanup(completeprompt, advancedprompting, insanitylevel = 5):
         completeprompt = completeprompt.replace("fluorescent", " ")
 
     # all cleanup steps moved here
-    completeprompt = re.sub('\[ ', '[', completeprompt)
-    completeprompt = re.sub('\[,', '[', completeprompt) 
-    completeprompt = re.sub(' \]', ']', completeprompt)
-    completeprompt = re.sub(' \|', '|', completeprompt)
-    #completeprompt = re.sub(' \"', '\"', completeprompt)
-    #completeprompt = re.sub('\" ', '\"', completeprompt)
-    completeprompt = re.sub('\( ', '(', completeprompt)
-    completeprompt = re.sub(' \(', '(', completeprompt)
-    completeprompt = re.sub('\) ', ')', completeprompt)
-    completeprompt = re.sub(' \)', ')', completeprompt)
+    completeprompt = re.sub(r'\[ ', '[', completeprompt)
+    completeprompt = re.sub(r'\[,', '[', completeprompt)
+    completeprompt = re.sub(r' \]', ']', completeprompt)
+    completeprompt = re.sub(r' \|', '|', completeprompt)
+    #completeprompt = re.sub(r' \"', '\"', completeprompt)
+    #completeprompt = re.sub(r'\" ', '\"', completeprompt)
+    completeprompt = re.sub(r'\( ', '(', completeprompt)
+    completeprompt = re.sub(r' \(', '(', completeprompt)
+    completeprompt = re.sub(r'\) ', ')', completeprompt)
+    completeprompt = re.sub(r' \)', ')', completeprompt)
 
     completeprompt = re.sub(' :', ':', completeprompt)
     completeprompt = re.sub(',::', '::', completeprompt)
@@ -4978,7 +4978,7 @@ def cleanup(completeprompt, advancedprompting, insanitylevel = 5):
     completeprompt = re.sub(' ,', ',', completeprompt)
     completeprompt = re.sub(' ,', ',', completeprompt)
     completeprompt = re.sub(' ,', ',', completeprompt)
-    completeprompt = re.sub(',\(', ', (', completeprompt)
+    completeprompt = re.sub(r',\(', ', (', completeprompt)
 
 
 
@@ -5048,17 +5048,17 @@ def cleanup(completeprompt, advancedprompting, insanitylevel = 5):
     completeprompt = re.sub(' mans', ' men', completeprompt)
     completeprompt = re.sub(' Womans,', ' Women', completeprompt)
     completeprompt = re.sub(' womans,', ' women,', completeprompt)
-    completeprompt = re.sub('\(Mans', '(Men,', completeprompt)
-    completeprompt = re.sub('\(mans', '(men', completeprompt)
-    completeprompt = re.sub('\(Womans', '(Women', completeprompt)
-    completeprompt = re.sub('\(womans', '(women', completeprompt)
+    completeprompt = re.sub(r'\(Mans', '(Men,', completeprompt)
+    completeprompt = re.sub(r'\(mans', '(men', completeprompt)
+    completeprompt = re.sub(r'\(Womans', '(Women', completeprompt)
+    completeprompt = re.sub(r'\(womans', '(women', completeprompt)
 
     completeprompt = re.sub('-sameothersubject-', 'it', completeprompt)
     completeprompt = re.sub('-samehumansubject-', 'the person', completeprompt)
 
     
-    completeprompt = re.sub('(?<!\()\s?\(', ' (', completeprompt)
-    completeprompt = re.sub('\)(?![\s)])', ') ', completeprompt)
+    completeprompt = re.sub(r'(?<!\()\s?\(', ' (', completeprompt)
+    completeprompt = re.sub(r'\)(?![\s)])', ') ', completeprompt)
 
     # Move the extracted LoRA's to the end of completeprompt
     #completeprompt += " " + " ".join(allLoRA)   

--- a/superprompter/superprompter.py
+++ b/superprompter/superprompter.py
@@ -3,7 +3,7 @@ import os
 import random
 import torch
 from transformers import T5Tokenizer, T5ForConditionalGeneration
-from superprompter.download_models import download_models
+from .download_models import download_models
 
 global tokenizer, model
 script_dir = os.path.dirname(os.path.abspath(__file__))  # Script directory

--- a/superprompter/superprompter.py
+++ b/superprompter/superprompter.py
@@ -3,7 +3,15 @@ import os
 import random
 import torch
 from transformers import T5Tokenizer, T5ForConditionalGeneration
-from .download_models import download_models
+
+if __package__ is None or __package__ == '':
+    # A1111 style (standalone script or direct module execution)
+    # Use absolute imports for compatibility with A1111 WebUI environment
+    from download_models import download_models
+else:
+    # ComfyUI style (imported as a package)
+    # Use relative imports for proper integration with ComfyUI
+    from .download_models import download_models
 
 global tokenizer, model
 script_dir = os.path.dirname(os.path.abspath(__file__))  # Script directory


### PR DESCRIPTION
fix: Changed to use relative imports
* The current import method causes import failures if the path name of a custom node changes (import failures occur when a new manager is introduced)

fix: Incorrect use of `\` in regex strings
* From Python 3.12 onwards, using the `\` character without explicitly using regex strings like r'\' is treated as a syntax error