### PR TITLE
Fix install from ComfyUI-Manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "onebuttonprompt"
+name = "OneButtonPrompt"
 description = "One Button Prompt has a prompt generation node for beginners who have problems writing a good prompt, or advanced users who want to get inspired. It generates an entire prompt from scratch. It is random, but controlled. You simply load up the script and press generate, and let it surprise you."
 version = "1.0.0"
 license = { file = "LICENSE" }


### PR DESCRIPTION
ComfyUI-Manager uses the value of "name" in pyproject.toml as the name of the directory for cloning extensions. Currently it is all lowercase. On Linux, filesystems are case-sensitive, so this breaks importing the nodes.

This PR capitalizes the "name" correctly so that the extension can be installed from the Manager on Linux successfully.

Closes #237