### PR TITLE
Fix ComfyUI node imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,8 +2,7 @@ import os
 import sys
 import folder_paths
 
-custom_nodes_path = os.path.join(folder_paths.base_path, "custom_nodes")
-onebuttonprompt_path = os.path.join(custom_nodes_path, "OneButtonPrompt")
+onebuttonprompt_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(onebuttonprompt_path)
 
 from .OneButtonPromptNodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS


### PR DESCRIPTION
My apologies, the previous fix for ComfyUI worked when I installed from my fork but doesn't with the main repo.

This fix uses the actual path to `__init__.py`, so it won't matter how the extension folder is named.

#237 #240
